### PR TITLE
Catch runtime error

### DIFF
--- a/bmi_ilamb/bmi_ilamb.py
+++ b/bmi_ilamb/bmi_ilamb.py
@@ -29,8 +29,10 @@ class BmiIlamb(Bmi):
         self._args = self.config.get_arguments()
 
     def update(self):
-        with open('stdout', 'w') as fp:
-            subprocess.check_call(self.args, stdout=fp)
+        with open('log', 'w') as fp:
+            subprocess.check_call(self.args,
+                                  stdout=fp,
+                                  stderr=subprocess.STDOUT)
         self._time = self.get_end_time()
 
     def update_until(self, time):

--- a/bmi_ilamb/bmi_ilamb.py
+++ b/bmi_ilamb/bmi_ilamb.py
@@ -29,11 +29,15 @@ class BmiIlamb(Bmi):
         self._args = self.config.get_arguments()
 
     def update(self):
-        with open('log', 'w') as fp:
-            subprocess.check_call(self.args,
-                                  stdout=fp,
-                                  stderr=subprocess.STDOUT)
-        self._time = self.get_end_time()
+        try:
+            with open('log', 'w') as fp:
+                subprocess.check_call(self.args,
+                                      stdout=fp,
+                                      stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            print 'Error in running ILAMB. Command:\n' + ' '.join(e.cmd)
+        finally:
+            self._time = self.get_end_time()
 
     def update_until(self, time):
         self.update()

--- a/bmi_ilamb/tests/test_bmi.py
+++ b/bmi_ilamb/tests/test_bmi.py
@@ -92,6 +92,5 @@ def test_update():
 def test_update_until():
     component = BmiIlamb()
     component.initialize(bmi_ilamb_config)
-    if ilamb_is_installed():
-        component.update_until(10.0)
+    component.update_until(10.0)
     component.finalize()

--- a/bmi_ilamb/tests/test_bmi.py
+++ b/bmi_ilamb/tests/test_bmi.py
@@ -92,5 +92,6 @@ def test_update():
 def test_update_until():
     component = BmiIlamb()
     component.initialize(bmi_ilamb_config)
-    component.update_until(10.0)
+    if ilamb_is_installed():
+        component.update_until(10.0)
     component.finalize()


### PR DESCRIPTION
When running ILAMB through its BMI, it would be helpful to capture stderr to a file along with stdout (which is already done). I've modified the code in the `update` method to do so. This should make it easier to debug runs when a user is scripting ILAMB and may not see terminal output.