### PR TITLE
Expose the 'build_dir' argument to ilamb-run in BMI config file

### DIFF
--- a/bmi_ilamb/data/bmi_ilamb.yaml
+++ b/bmi_ilamb/data/bmi_ilamb.yaml
@@ -3,6 +3,7 @@
 # config         path to ILAMB config file
 # ilamb_root     where benchmarks and model outputs are located
 # model_root     location of model outputs, relative to ilamb_root
+# build_dir      where analysis results are saved
 # regions        regions over which analysis is performed
 # models         a list of models to benchmark
 # confrontations a list of confrontations to run
@@ -10,6 +11,7 @@
 config: /home/csdms/wmt/_testing/opt/bmi-ilamb/bmi_ilamb/data/ilamb.cfg
 ilamb_root: /nas/data/ILAMB_sample
 model_root: MODELS  # relative to ilamb_root
+build_dir:
 regions:
 models:
 confrontations:

--- a/bmi_ilamb/data/bmi_ilamb_with_build_dir.yaml
+++ b/bmi_ilamb/data/bmi_ilamb_with_build_dir.yaml
@@ -11,9 +11,7 @@
 config: /home/csdms/wmt/_testing/opt/bmi-ilamb/bmi_ilamb/data/ilamb.cfg
 ilamb_root: /nas/data/ILAMB_sample
 model_root: MODELS  # relative to ilamb_root
-build_dir:
+build_dir: __build_dir__
 regions:
 models:
-  - CLM40cn
 confrontations:
-  - ConfNBP

--- a/bmi_ilamb/data/bmi_ilamb_with_models.yaml
+++ b/bmi_ilamb/data/bmi_ilamb_with_models.yaml
@@ -3,6 +3,7 @@
 # config         path to ILAMB config file
 # ilamb_root     where benchmarks and model outputs are located
 # model_root     location of model outputs, relative to ilamb_root
+# build_dir      where analysis results are saved
 # regions        regions over which analysis is performed
 # models         a list of models to benchmark
 # confrontations a list of confrontations to run
@@ -10,6 +11,7 @@
 config: /home/csdms/wmt/_testing/opt/bmi-ilamb/bmi_ilamb/data/ilamb.cfg
 ilamb_root: /nas/data/ILAMB_sample
 model_root: MODELS  # relative to ilamb_root
+build_dir:
 regions:
 models:
   - CLM40cn

--- a/bmi_ilamb/data/bmi_ilamb_with_regions.yaml
+++ b/bmi_ilamb/data/bmi_ilamb_with_regions.yaml
@@ -3,6 +3,7 @@
 # config         path to ILAMB config file
 # ilamb_root     where benchmarks and model outputs are located
 # model_root     location of model outputs, relative to ilamb_root
+# build_dir      where analysis results are saved
 # regions        regions over which analysis is performed
 # models         a list of models to benchmark
 # confrontations a list of confrontations to run
@@ -10,6 +11,7 @@
 config: /home/csdms/wmt/_testing/opt/bmi-ilamb/bmi_ilamb/data/ilamb.cfg
 ilamb_root: /nas/data/ILAMB_sample
 model_root: MODELS  # relative to ilamb_root
+build_dir:
 regions: arctic
 models:
 confrontations:

--- a/bmi_ilamb/tests/test_config.py
+++ b/bmi_ilamb/tests/test_config.py
@@ -121,3 +121,18 @@ def test_get_arguments_with_regions():
     x.load(cfg)
     r = x.get_arguments()
     assert_equal(len(r), 6)
+
+
+def test_get_arguments_no_build_dir():
+    x = Configuration()
+    x.load(bmi_ilamb_config)
+    r = x.get_arguments()
+    assert_equal(len(r), 4)
+
+
+def test_get_arguments_with_build_dir():
+    x = Configuration()
+    cfg = os.path.join(data_dir, 'bmi_ilamb_with_build_dir.yaml')
+    x.load(cfg)
+    r = x.get_arguments()
+    assert_equal(len(r), 6)


### PR DESCRIPTION
Now `build_dir` is an attribute in the BMI YAML config file. If empty, it defaults to the default for `ilamb-run`.