### PR TITLE
Use pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,11 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - conda install nose
-  - pip install basic-modeling-interface pyyaml
-  - pip install coveralls
+  - conda install pyyaml pytest pytest-cov coveralls
+  - pip install basic-modeling-interface
 install:
   - python setup.py install
 script:
-  - nosetests --with-doctest --with-coverage --cover-package=bmi_ilamb
+  - pytest --cov=bmi_ilamb --cov-report=html --cov-config=setup.cfg
 after_success:
   - coveralls --verbose

--- a/bmi_ilamb/tests/test_bmi.py
+++ b/bmi_ilamb/tests/test_bmi.py
@@ -1,7 +1,8 @@
 """Unit tests for the ILAMB BMI."""
 
 import os
-from nose.tools import raises, assert_is, assert_equal, assert_true
+import pytest
+
 from bmi_ilamb import BmiIlamb
 from . import ilamb_is_installed
 from .. import data_dir
@@ -13,49 +14,48 @@ bmi_ilamb_config = os.path.join(data_dir, 'bmi_ilamb.yaml')
 def test_component_name():
     component = BmiIlamb()
     name = component.get_component_name()
-    assert_equal(name, 'ILAMB')
-    assert_is(component.get_component_name(), name)
+    assert name == 'ILAMB'
 
 
 def test_start_time():
     component = BmiIlamb()
-    assert_equal(component.get_start_time(), 0.0)
+    assert component.get_start_time() == 0.0
 
 
 def test_end_time():
     component = BmiIlamb()
-    assert_equal(component.get_end_time(), 1.0)
+    assert component.get_end_time() == 1.0
 
 
 def test_current_time():
     component = BmiIlamb()
-    assert_equal(component.get_current_time(), 0.0)
+    assert component.get_current_time() == 0.0
 
 
 def test_time_step():
     component = BmiIlamb()
-    assert_equal(component.get_time_step(), 1.0)
+    assert component.get_time_step() == 1.0
 
 
 def test_time_units():
     component = BmiIlamb()
-    assert_equal(component.get_time_units(), 's')
+    assert component.get_time_units() == 's'
 
 
 def test_get_input_var_names():
     component = BmiIlamb()
-    assert_equal(component.get_input_var_names(), ())
+    assert component.get_input_var_names() == ()
 
 
 def test_get_output_var_names():
     component = BmiIlamb()
-    assert_equal(component.get_output_var_names(), ())
+    assert component.get_output_var_names() == ()
 
 
-@raises(TypeError)
 def test_initialize_no_argument():
     component = BmiIlamb()
-    component.initialize()
+    with pytest.raises(TypeError):
+        component.initialize()
 
 
 def test_initialize():
@@ -66,14 +66,14 @@ def test_initialize():
 def test_initialize_n_arguments():
     component = BmiIlamb()
     component.initialize(bmi_ilamb_config)
-    assert_equal(len(component.args), 5)
+    assert len(component.args) == 5
 
 
 def test_initialize_sets_env_vars():
     component = BmiIlamb()
     component.initialize(bmi_ilamb_config)
-    assert_true(os.environ.has_key('ILAMB_ROOT'))
-    assert_true(os.environ.has_key('MPLBACKEND'))
+    assert os.environ.has_key('ILAMB_ROOT')
+    assert os.environ.has_key('MPLBACKEND')
 
 
 def test_finalize():
@@ -101,4 +101,4 @@ def test_str():
     component = BmiIlamb()
     component.initialize(bmi_ilamb_config)
     s = str(component)
-    assert_is(type(s), str)
+    assert type(s) is str

--- a/bmi_ilamb/tests/test_config.py
+++ b/bmi_ilamb/tests/test_config.py
@@ -1,8 +1,8 @@
 """Unit tests for the bmi_ilamb.config.Configuration class."""
 
 import os
-from nose.tools import (raises, assert_equal, assert_is, assert_true,
-                        assert_is_instance, assert_is_none)
+import pytest
+
 from ..config import Configuration
 from .. import data_dir
 
@@ -12,24 +12,24 @@ bmi_ilamb_config = os.path.join(data_dir, 'bmi_ilamb.yaml')
 
 def test_configuration_instantiates():
     x = Configuration()
-    assert_is_instance(x, Configuration)
+    assert isinstance(x, Configuration)
 
 
 def test_configuration_instantiates_with_filename():
     x = Configuration(bmi_ilamb_config)
-    assert_is_instance(x, Configuration)
+    assert isinstance(x, Configuration)
 
 
-@raises(TypeError)
 def test_load_fails_with_no_argument():
     x = Configuration()
-    x.load()
+    with pytest.raises(TypeError):
+        x.load()
 
 
-@raises(IOError)
 def test_load_fails_with_nonexistent_file():
     x = Configuration()
-    x.load('foo.txt')
+    with pytest.raises(IOError):
+        x.load('foo.txt')
 
 
 def test_load():
@@ -40,14 +40,14 @@ def test_load():
 def test_get_ilamb_root_returns_none_before_load():
     x = Configuration()
     r = x.get_ilamb_root()
-    assert_is_none(r)
+    assert r is None
 
 
 def test_get_ilamb_root():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_ilamb_root()
-    assert_is(type(r), str)
+    assert type(r) is str
 
 
 def test_set_model_root():
@@ -55,34 +55,34 @@ def test_set_model_root():
     x.load(bmi_ilamb_config)
     x._set_model_root()
     r = x._config['model_root']
-    assert_true(os.path.isabs(r))
+    assert os.path.isabs(r)
 
 
 def test_get_arguments_returns_list_before_load():
     x = Configuration()
     r = x.get_arguments()
-    assert_is(type(r), list)
+    assert type(r) is list
 
 
 def test_get_arguments_omits_ilamb_root():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(r.count('ilamb_root'), 0)
+    assert r.count('ilamb_root') == 0
 
 
 def test_get_arguments():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_no_models():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_with_models():
@@ -90,14 +90,14 @@ def test_get_arguments_with_models():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_models.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 7)
+    assert len(r) == 7
 
 
 def test_get_arguments_no_confrontations():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_with_confrontations():
@@ -105,14 +105,14 @@ def test_get_arguments_with_confrontations():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_confrontations.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 8)
+    assert len(r) == 8
 
 
 def test_get_arguments_no_regions():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_with_regions1():
@@ -120,7 +120,7 @@ def test_get_arguments_with_regions1():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_regions_1.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 6)
+    assert len(r) == 6
 
 
 def test_get_arguments_with_regions2():
@@ -128,14 +128,14 @@ def test_get_arguments_with_regions2():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_regions_2.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 8)
+    assert len(r) == 8
 
 
 def test_get_arguments_no_build_dir():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_with_build_dir():
@@ -143,14 +143,14 @@ def test_get_arguments_with_build_dir():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_build_dir.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 6)
+    assert len(r) == 6
 
 
 def test_get_arguments_no_user_regions():
     x = Configuration()
     x.load(bmi_ilamb_config)
     r = x.get_arguments()
-    assert_equal(len(r), 4)
+    assert len(r) == 4
 
 
 def test_get_arguments_with_netcdf_user_regions():
@@ -158,7 +158,7 @@ def test_get_arguments_with_netcdf_user_regions():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_custom_regions_nc.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 10)
+    assert len(r) == 10
 
 
 def test_get_arguments_with_text_user_regions():
@@ -166,4 +166,4 @@ def test_get_arguments_with_text_user_regions():
     cfg = os.path.join(data_dir, 'bmi_ilamb_with_custom_regions_txt.yaml')
     x.load(cfg)
     r = x.get_arguments()
-    assert_equal(len(r), 8)
+    assert len(r) == 8

--- a/bmi_ilamb/tests/test_package_directories.py
+++ b/bmi_ilamb/tests/test_package_directories.py
@@ -1,21 +1,21 @@
 """Tests directories set in the package definition file."""
 
 import os
-from nose.tools import assert_true
+
 from .. import package_dir, data_dir
 
 
 def test_package_dir_is_set():
-    assert(package_dir is not None)
+    assert package_dir is not None
 
 
 def test_data_dir_is_set():
-    assert(data_dir is not None)
+    assert data_dir is not None
 
 
 def test_package_dir_exists():
-    assert_true(os.path.isdir(package_dir))
+    assert os.path.isdir(package_dir) is True
 
 
 def test_data_dir_exists():
-    assert_true(os.path.isdir(data_dir))
+    assert os.path.isdir(data_dir) is True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[tool:pytest]
+minversion = 3.0
+testpaths = bmi_ilamb
+norecursedirs = .* *.egg* build dist
+# usefixtures = suppress_resource_warning
+addopts =
+    --ignore setup.py
+    --ignore bmi_ilamb/version.py
+    --tb native
+    --strict
+    --durations 3
+    --doctest-modules
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
+    ALLOW_UNICODE

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='bmi-ilamb',
       install_requires=['pyyaml', 'basic-modeling-interface'],
       keywords='CSDMS BMI ILAMB model benchmark',
       classifiers=[
-          'Development Status :: 3 - Alpha',
+          'Development Status :: 5 - Production/Stable',
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python :: 2.7',
       ],


### PR DESCRIPTION
Nose is fading, so I've switched to pytest for a unit testing framework. I updated all tests and now call `pytest` instead of `nosetests` in the Travis CI file.